### PR TITLE
Refactor chunk loading utilities

### DIFF
--- a/chunkloading.py
+++ b/chunkloading.py
@@ -1,14 +1,54 @@
+"""Utilities for splitting and persisting map layers in chunks.
+
+This module provides helper functions for breaking large map arrays into
+smaller pieces that can be saved and loaded independently.  The original
+version tightly coupled chunk handling with the map generation module,
+which made it difficult to test in isolation.  The updated version works
+with plain NumPy arrays and includes a small demo that round-trips random
+data through the API.
+"""
+
+from typing import Dict, Tuple
+
 import h5py
-from _map.map_generation import *
+import numpy as np
+
 
 class ChunkGenerator:
+    """Helper methods for working with map chunks."""
 
     @staticmethod
-    def generate_chunks(terrain, biomes, temperature, precipitation, chunk_size=32):
-        terrain_chunks = {}
-        biome_chunks = {}
-        temperature_chunks = {}
-        precipitation_chunks = {}
+    def generate_chunks(
+        terrain: np.ndarray,
+        biomes: np.ndarray,
+        temperature: np.ndarray,
+        precipitation: np.ndarray,
+        chunk_size: int = 32,
+    ) -> Tuple[
+        Dict[str, np.ndarray],
+        Dict[str, np.ndarray],
+        Dict[str, np.ndarray],
+        Dict[str, np.ndarray],
+    ]:
+        """Split full map layers into equally sized chunks.
+
+        Parameters
+        ----------
+        terrain, biomes, temperature, precipitation:
+            Full-sized arrays representing different map layers.
+        chunk_size:
+            The width/height of each square chunk.
+
+        Returns
+        -------
+        Tuple of dictionaries keyed by "y_x" chunk coordinates containing
+        the corresponding sub-arrays for each map layer.
+        """
+
+        terrain_chunks: Dict[str, np.ndarray] = {}
+        biome_chunks: Dict[str, np.ndarray] = {}
+        temperature_chunks: Dict[str, np.ndarray] = {}
+        precipitation_chunks: Dict[str, np.ndarray] = {}
 
         height, width = terrain.shape
 
@@ -16,16 +56,22 @@ class ChunkGenerator:
             for x in range(0, width, chunk_size):
                 coordinates = f"{y // chunk_size}_{x // chunk_size}"
 
-
-                terrain_chunks[coordinates] = terrain[y:y+chunk_size, x:x+chunk_size]
-                biome_chunks[coordinates] = biomes[y:y+chunk_size, x:x+chunk_size]
-                temperature_chunks[coordinates] = temperature[y:y+chunk_size, x:x+chunk_size]
-                precipitation_chunks[coordinates] = precipitation[y:y+chunk_size, x:x+chunk_size]
+                terrain_chunks[coordinates] = terrain[y : y + chunk_size, x : x + chunk_size]
+                biome_chunks[coordinates] = biomes[y : y + chunk_size, x : x + chunk_size]
+                temperature_chunks[coordinates] = temperature[y : y + chunk_size, x : x + chunk_size]
+                precipitation_chunks[coordinates] = precipitation[y : y + chunk_size, x : x + chunk_size]
 
         return terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks
 
     @staticmethod
-    def save_chunks(terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks, filename):
+    def save_chunks(
+        terrain_chunks: Dict[str, np.ndarray],
+        biome_chunks: Dict[str, np.ndarray],
+        temperature_chunks: Dict[str, np.ndarray],
+        precipitation_chunks: Dict[str, np.ndarray],
+        filename: str,
+    ) -> None:
+        """Persist chunk dictionaries to an HDF5 file."""
         filename = filename + ".h5"
         with h5py.File(filename, "w") as h5file:
             terrain_group = h5file.create_group("terrain")
@@ -48,29 +94,68 @@ class ChunkGenerator:
                 )
 
     @staticmethod
-    def load_chunks(filename):
+    def load_chunks(
+        filename: str,
+    ) -> Tuple[
+        Dict[str, np.ndarray],
+        Dict[str, np.ndarray],
+        Dict[str, np.ndarray],
+        Dict[str, np.ndarray],
+    ]:
+        """Load chunk dictionaries from an HDF5 file."""
         filename = filename + ".h5"
         with h5py.File(filename, "r") as h5file:
             terrain_chunks = {key: np.array(h5file[f"terrain/{key}"]) for key in h5file["terrain"].keys()}
             biome_chunks = {key: np.array(h5file[f"biomes/{key}"]) for key in h5file["biomes"].keys()}
             temperature_chunks = {key: np.array(h5file[f"temperature/{key}"]) for key in h5file["temperature"].keys()}
-            precipitation_chunks = {key: np.array(h5file[f"precipitation/{key}"]) for key in
-                                    h5file["precipitation"].keys()}
+            precipitation_chunks = {
+                key: np.array(h5file[f"precipitation/{key}"]) for key in h5file["precipitation"].keys()
+            }
 
         return terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks
 
+    @staticmethod
+    def reconstruct_layer(
+        chunks: Dict[str, np.ndarray], chunk_size: int, height: int, width: int
+    ) -> np.ndarray:
+        """Reassemble a full map layer from its chunks.
 
-def main():
-    terrain, biomes, temperature, precipitation, fig, seed = generate_medieval_rpg_map_2d(1024, 1024)
-    terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks = ChunkGenerator.generate_chunks(terrain, biomes, temperature, precipitation)
+        Parameters
+        ----------
+        chunks: dict
+            Dictionary of chunk arrays keyed by "y_x" coordinates.
+        chunk_size: int
+            Size of each square chunk.
+        height, width: int
+            Dimensions of the resulting array.
+        """
+
+        full = np.zeros((height, width), dtype=next(iter(chunks.values())).dtype)
+        for coord, data in chunks.items():
+            cy, cx = map(int, coord.split("_"))
+            y, x = cy * chunk_size, cx * chunk_size
+            full[y : y + data.shape[0], x : x + data.shape[1]] = data
+        return full
+
+
+def main() -> None:
+    """Simple demonstration that round-trips random data through the API."""
+    height = width = 64
+    terrain = np.random.rand(height, width)
+    biomes = np.random.randint(0, 5, size=(height, width))
+    temperature = np.random.rand(height, width)
+    precipitation = np.random.rand(height, width)
+
+    terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks = ChunkGenerator.generate_chunks(
+        terrain, biomes, temperature, precipitation
+    )
     ChunkGenerator.save_chunks(terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks, "test_chunks")
     terrain_chunks, biome_chunks, temperature_chunks, precipitation_chunks = ChunkGenerator.load_chunks("test_chunks")
 
-    print(terrain_chunks)
-    print(biome_chunks)
-    print(temperature_chunks)
-    print(precipitation_chunks)
+    terrain_recon = ChunkGenerator.reconstruct_layer(terrain_chunks, 32, height, width)
+    assert np.allclose(terrain, terrain_recon)
+    print("Chunk round-trip successful; data reconstructed correctly.")
+
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- decouple chunkloader from map generation and clean up imports
- add `reconstruct_layer` helper and enrich documentation for chunk utilities
- include runnable demo showing round trip save/load

## Testing
- `python -m py_compile chunkloading.py`
- `python chunkloading.py`


------
https://chatgpt.com/codex/tasks/task_e_68997c66a7d4832da418a169eb5cef52